### PR TITLE
Move interfaces to Chirp.Core

### DIFF
--- a/src/Chirp.Core/CheepDTO.cs
+++ b/src/Chirp.Core/CheepDTO.cs
@@ -1,4 +1,4 @@
-﻿namespace Chirp.Infrastructure;
+﻿namespace Chirp.Core;
 
 public class CheepDTO
 {

--- a/src/Chirp.Core/RepositoryInterfaces/IAuthorRepository.cs
+++ b/src/Chirp.Core/RepositoryInterfaces/IAuthorRepository.cs
@@ -1,4 +1,4 @@
-namespace Chirp.Infrastructure.Repositories;
+namespace Chirp.Core.RepositoryInterfaces;
 
 public interface IAuthorRepository
 {

--- a/src/Chirp.Core/RepositoryInterfaces/ICheepRepository.cs
+++ b/src/Chirp.Core/RepositoryInterfaces/ICheepRepository.cs
@@ -1,6 +1,6 @@
 ﻿using Chirp.Core.DomainModel;
 
-namespace Chirp.Infrastructure.Repositories;
+namespace Chirp.Core.RepositoryInterfaces;
 
 public interface ICheepRepository
 {
@@ -8,7 +8,6 @@ public interface ICheepRepository
     public Task<List<Cheep>> ReadCheepsFrom(int page, int authorId);
     public Task<int> GetTotalCheeps();
     public Task<int> GetTotalCheepsFor(int authorId);
-    
     public Task CreateCheep(CheepDTO newCheep);
     public Task AddCheep(Cheep cheep);
 }

--- a/src/Chirp.Core/ServiceInterfaces/IAuthorService.cs
+++ b/src/Chirp.Core/ServiceInterfaces/IAuthorService.cs
@@ -1,0 +1,8 @@
+namespace Chirp.Core.ServiceInterfaces;
+
+public interface IAuthorService
+{
+    int CurrentPage { get; set; }
+    public Task<List<CheepDTO>> GetAuthorCheeps(string author);
+    public Task<int> GetTotalAuthorCheeps(string author);
+}

--- a/src/Chirp.Core/ServiceInterfaces/ICheepService.cs
+++ b/src/Chirp.Core/ServiceInterfaces/ICheepService.cs
@@ -1,0 +1,8 @@
+namespace Chirp.Core.ServiceInterfaces;
+
+public interface ICheepService
+{
+    int CurrentPage { get; set; }
+    public Task<List<CheepDTO>> GetCheeps();
+    public Task<int> GetTotalCheeps();
+}

--- a/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
@@ -1,4 +1,5 @@
 using Chirp.Core.DomainModel;
+using Chirp.Core.RepositoryInterfaces;
 using Chirp.Infrastructure.Database;
 
 using Microsoft.EntityFrameworkCore;

--- a/src/Chirp.Infrastructure/Services/AuthorService.cs
+++ b/src/Chirp.Infrastructure/Services/AuthorService.cs
@@ -1,14 +1,10 @@
 using System.Globalization;
-using Chirp.Infrastructure.Repositories;
+
+using Chirp.Core;
+using Chirp.Core.RepositoryInterfaces;
+using Chirp.Core.ServiceInterfaces;
 
 namespace Chirp.Infrastructure.Services;
-
-public interface IAuthorService
-{
-    int CurrentPage { get; set; }
-    public Task<List<CheepDTO>> GetAuthorCheeps(string author);
-    public Task<int> GetTotalAuthorCheeps(string author);
-}
 
 public class AuthorService : IAuthorService
 {

--- a/src/Chirp.Infrastructure/Services/CheepService.cs
+++ b/src/Chirp.Infrastructure/Services/CheepService.cs
@@ -1,15 +1,10 @@
 using System.Globalization;
-using Chirp.Infrastructure.Repositories;
+
+using Chirp.Core;
+using Chirp.Core.RepositoryInterfaces;
+using Chirp.Core.ServiceInterfaces;
 
 namespace Chirp.Infrastructure.Services;
-
-public interface ICheepService
-{
-    int CurrentPage { get; set; }
-    public Task<List<CheepDTO>> GetCheeps();
-    public Task<int> GetTotalCheeps();
-}
-
 public class CheepService : ICheepService
 {
     private const int PAGE_SIZE = 32;

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Chirp.Infrastructure\Chirp.Infrastructure.csproj" />
+        <ProjectReference Include="..\..\src\Chirp.Core\Chirp.Core.csproj" />
     </ItemGroup>
     
 </Project>

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Chirp.Core;
+using Chirp.Core.ServiceInterfaces;
+
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Chirp.Infrastructure;
 using Chirp.Infrastructure.Services;

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using Chirp.Infrastructure;
+﻿using Chirp.Core;
+using Chirp.Core.ServiceInterfaces;
+using Chirp.Infrastructure;
 using Chirp.Infrastructure.Services;
 
 using Microsoft.AspNetCore.Mvc;
@@ -6,16 +8,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Chirp.Web.Pages;
 
-public class UserTimelineModel : PageModel
+public class UserTimelineModel(IAuthorService service) : PageModel
 {
-    private readonly IAuthorService _service;
     public required List<CheepDTO> Cheeps { get; set; }
     public int TotalAuthorPages { get; private set; }
     public int CurrentPage;
-    public UserTimelineModel(IAuthorService service)
-    {
-        _service = service;
-    }
 
     public async Task<ActionResult> OnGetAsync(string author)
     {
@@ -23,9 +20,9 @@ public class UserTimelineModel : PageModel
         {
             int pageQuery = Request.Query.ContainsKey("page") ? Convert.ToInt32(Request.Query["page"]) : 1;
             if (pageQuery < 1) throw new ArgumentOutOfRangeException();
-            _service.CurrentPage = pageQuery;
-            Cheeps = await _service.GetAuthorCheeps(author);
-            TotalAuthorPages = await _service.GetTotalAuthorCheeps(author);
+            service.CurrentPage = pageQuery;
+            Cheeps = await service.GetAuthorCheeps(author);
+            TotalAuthorPages = await service.GetTotalAuthorCheeps(author);
             CurrentPage = pageQuery;
         }    catch (FormatException)
         {

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -1,3 +1,5 @@
+using Chirp.Core.RepositoryInterfaces;
+using Chirp.Core.ServiceInterfaces;
 using Chirp.Infrastructure.Database;
 using Chirp.Infrastructure.Repositories;
 using Chirp.Infrastructure.Services;

--- a/test/Chirp.Tests/CheepServiceTests.cs
+++ b/test/Chirp.Tests/CheepServiceTests.cs
@@ -1,4 +1,6 @@
+using Chirp.Core;
 using Chirp.Core.DomainModel;
+using Chirp.Core.RepositoryInterfaces;
 using Chirp.Infrastructure;
 using Chirp.Infrastructure.Repositories;
 using Chirp.Infrastructure.Services;


### PR DESCRIPTION
As per request of TA, I have moved the interfaces to Core. Interfaces found within the class that implements them have also been moved out to their own class.