### PR TITLE
Fix CheepRepository + Service UnitTests

### DIFF
--- a/test/Chirp.Tests/CheepServiceTests.cs
+++ b/test/Chirp.Tests/CheepServiceTests.cs
@@ -123,7 +123,7 @@ public class CheepServiceTests
         // Assert
         var createdCheeps = fakeCheepRepository.GetCreatedCheeps();
         Assert.Single(createdCheeps);
-        Assert.Equal("alice@alice.com", createdCheeps[0].Author);
+        Assert.Equal("alice@alice.com", createdCheeps[0].UserName);
         Assert.Equal("Hey this is a test", createdCheeps[0].Message);
     }
 
@@ -145,7 +145,7 @@ public class CheepServiceTests
         Assert.Single(createdCheeps);
 
         var storedCheeps = createdCheeps[0];
-        Assert.Equal(author, storedCheeps.Author);
+        Assert.Equal(author, storedCheeps.UserName);
         Assert.Equal(message, storedCheeps.Message);
     }
 


### PR DESCRIPTION
After the Identity refactor, these tests were not fixed. Also one of the tests was wrong in that it used the DBInitialiser to seed the test database, however that seeder does not contain the author "Alice", as is tested against. This was probably meant to test against the SeedDatabase static method present in the test class instead.